### PR TITLE
Auto-load coordinates from sample folder

### DIFF
--- a/detectX3.py
+++ b/detectX3.py
@@ -1,96 +1,88 @@
 import cv2
-import sys
 import csv
 import numpy as np
 import os
 
 def loadtxtmethod(filename):
-    data = np.loadtxt(filename,dtype=np.float32,delimiter=',')
-    return data
+    """Load numeric data from a comma separated text file."""
+    return np.loadtxt(filename, dtype=np.float32, delimiter=',')
+
+
+def process_image(img_path, txt_path, out_csv=None):
+    """Process a single image and corresponding coordinate text.
+
+    Parameters
+    ----------
+    img_path : str
+        Path to the processed image.
+    txt_path : str
+        Path to the text file containing geographic information.
+    out_csv : str, optional
+        If given, detected coordinates will be written to this CSV file.
+
+    Returns
+    -------
+    tuple of lists
+        Lists of detected longitude and latitude values.
+    """
+
+    data = loadtxtmethod(txt_path)
+
+    b = float(data[0])
+    a = float(data[3])
+    d = float(data[2])
+    c = float(data[1])
+    e = float(data[4])
+    f = float(data[5])
+
+    CoordinateX = []  # X coordinate collection
+    CoordinateY = []  # Y coordinate collection
+
+    img = cv2.imread(img_path)
+    grid_RGB = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    grid_HSV = cv2.cvtColor(grid_RGB, cv2.COLOR_RGB2HSV)
+
+    lower1 = np.array([0, 43, 46])
+    upper1 = np.array([10, 255, 255])
+    mask1 = cv2.inRange(grid_HSV, lower1, upper1)
+
+    lower2 = np.array([156, 43, 46])
+    upper2 = np.array([180, 255, 255])
+    mask2 = cv2.inRange(grid_HSV, lower2, upper2)
+
+    lower3 = np.array([35, 43, 46])
+    upper3 = np.array([77, 255, 255])
+    mask3 = cv2.inRange(grid_HSV, lower3, upper3)
+
+    mask4 = mask1 + mask2 + mask3
+
+    xy = np.column_stack(np.where(mask4 == 255))
+
+    for t in xy:
+        CoordinateX.append(c + int(t[1]) * ((a - c) / e))
+        CoordinateY.append(d - int(t[0]) * ((d - b) / f))
+
+    if out_csv is not None:
+        with open(out_csv, "w", encoding="utf8", newline="") as csvFile:
+            writer = csv.writer(csvFile)
+            for x, y in zip(CoordinateX, CoordinateY):
+                writer.writerow([x, y])
+
+    return CoordinateX, CoordinateY
 
 if __name__ == "__main__":
+    path = os.path.join("样例", "img_out")
+    path2 = os.path.join("样例", "txt_out")
 
-    path = "img_out/"
-    path2 = "txt_out/"
-
-    for filename in os.listdir(path):  # listdir的参数是文件夹的路径
-        print(filename)  # 此时的filename是文件夹中文件的名称
-
-        img_path = path + '/' + filename
-        txt_path = path2 + '/' + str(filename[:-4])+".txt"
-
-        data = loadtxtmethod(txt_path)
-        print(data)
-
-        b = float(data[0])
-        a = float(data[3])
-        d = float(data[2])
-        c = float(data[1])
-        e = float(data[4])
-        f = float(data[5])
-
-        CoordinateX = []  # 选中点的X坐标集合
-        CoordinateY = []  # 选中点的Y坐标集合
-
-        img = cv2.imread(img_path)
-        # 在彩色图像的情况下，解码图像将以b g r顺序存储通道。
-        grid_RGB = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-
-        # 从RGB色彩空间转换到HSV色彩空间
-        grid_HSV = cv2.cvtColor(grid_RGB, cv2.COLOR_RGB2HSV)
-
-        # H、S、V范围一：
-        lower1 = np.array([0, 43, 46])
-        upper1 = np.array([10, 255, 255])
-        mask1 = cv2.inRange(grid_HSV, lower1, upper1)  # mask1 为二值图像
-        # res1 = cv2.bitwise_and(grid_RGB, grid_RGB, mask=mask1)
-
-        # H、S、V范围二：
-        lower2 = np.array([156, 43, 46])
-        upper2 = np.array([180, 255, 255])
-        mask2 = cv2.inRange(grid_HSV, lower2, upper2)
-        # res2 = cv2.bitwise_and(grid_RGB, grid_RGB, mask=mask2)
-
-        # H、S、V范围三：
-        lower3 = np.array([35, 43, 46])
-        upper3 = np.array([77, 255, 255])
-        mask3 = cv2.inRange(grid_HSV, lower3, upper3)
-        # res2 = cv2.bitwise_and(grid_RGB, grid_RGB, mask=mask2)
-
-        # 将三个二值图像结果 相加
-        mask4 = mask1 + mask2 + mask3
-
-        xy = np.column_stack(np.where(mask4 == 255))
-        print(xy)
-
-        for t in xy:
-
-            # CoordinateX = c + int(t[1]) * ((a - c) / e)
-            # CoordinateY = d - int(t[0]) * ((d - b) / f)
-            CoordinateX.append(c + int(t[1]) * ((a - c) / e))
-            CoordinateY.append(d - int(t[0]) * ((d - b) / f))
-
-
-
-            # print(CoordinateX)
-            # print(CoordinateY)
-
-
-        print(CoordinateX)
-        print(CoordinateY)
-
-        # 坐标:c[1]是x,c[0]是y
-        # print(int(t[1]), int(t[0]))
-        # cv2.namedWindow("mask3", cv2.WINDOW_NORMAL)
-
-        cv2.waitKey(0)
-        cv2.destroyAllWindows()
-
-        csvFile = open(str(filename[:-4])+".csv", "w", encoding='utf8', newline='')  # 创建csv文件
-        writer = csv.writer(csvFile)  # 创建写的对象
-        for i in range(len(CoordinateX)):
-            writer.writerow([CoordinateX[i], CoordinateY[i]])
-        csvFile.close()
+    for filename in os.listdir(path):
+        if not filename.lower().endswith((".jpg", ".png", ".jpeg", ".bmp", ".tif")):
+            continue
+        img_path = os.path.join(path, filename)
+        txt_path = os.path.join(path2, f"{os.path.splitext(filename)[0]}.txt")
+        out_csv = f"{os.path.splitext(filename)[0]}.csv"
+        xs, ys = process_image(img_path, txt_path, out_csv=out_csv)
+        print(xs)
+        print(ys)
 
 
 

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,144 @@
+import os
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+from PIL import Image, ImageTk, ImageDraw
+
+import predict
+import detectX3
+
+IMG_DIR = os.path.join('样例', 'img')
+OUT_DIR = os.path.join('样例', 'img_out')
+TXT_DIR = os.path.join('样例', 'txt_out')
+
+class App(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title('卫星图像处理系统')
+        self.geometry('1000x600')
+
+        self.img_path = None
+        self.txt_path = None
+
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=2)
+        self.columnconfigure(2, weight=2)
+        self.rowconfigure(0, weight=1)
+
+        self.ctrl_panel = ttk.LabelFrame(self, text='控制面板')
+        self.ctrl_panel.grid(row=0, column=0, sticky='nswe', padx=5, pady=5)
+        self.ctrl_panel.columnconfigure(0, weight=1)
+
+        self.btn_load_img = ttk.Button(self.ctrl_panel, text='加载图像', command=self.load_image)
+        self.btn_load_img.grid(row=0, column=0, pady=5, sticky='ew')
+
+        self.btn_load_coord = ttk.Button(self.ctrl_panel, text='加载坐标', command=self.load_coord)
+        self.btn_load_coord.grid(row=1, column=0, pady=5, sticky='ew')
+
+        ttk.Label(self.ctrl_panel, text='坐标类型').grid(row=2, column=0, pady=(5,0), sticky='w')
+        self.dd_coord = ttk.Combobox(self.ctrl_panel, values=['默认'])
+        self.dd_coord.current(0)
+        self.dd_coord.grid(row=3, column=0, sticky='ew')
+
+        self.btn_seg = ttk.Button(self.ctrl_panel, text='U-Net分割', command=self.run_predict)
+        self.btn_seg.grid(row=4, column=0, pady=5, sticky='ew')
+
+        self.btn_detect = ttk.Button(self.ctrl_panel, text='坐标检测', command=self.run_detect)
+        self.btn_detect.grid(row=5, column=0, pady=5, sticky='ew')
+
+        self.status_var = tk.StringVar(value='就绪')
+        self.status = ttk.Label(self.ctrl_panel, textvariable=self.status_var)
+        self.status.grid(row=6, column=0, pady=5)
+
+        self.progress = ttk.Progressbar(self.ctrl_panel, mode='indeterminate')
+        self.progress.grid(row=7, column=0, pady=5, sticky='ew')
+
+        self.canvas_orig = ttk.Label(self)
+        self.canvas_orig.grid(row=0, column=1, sticky='nsew')
+
+        self.canvas_res = ttk.Label(self)
+        self.canvas_res.grid(row=0, column=2, sticky='nsew')
+
+    def set_status(self, text, color='black'):
+        self.status_var.set(text)
+        self.status.configure(foreground=color)
+        self.update_idletasks()
+
+    def load_image(self):
+        filetypes = [('Images','*.jpg *.png *.jpeg *.bmp *.tif')]
+        fname = filedialog.askopenfilename(initialdir=IMG_DIR, filetypes=filetypes)
+        if not fname:
+            return
+        self.img_path = fname
+        # try to locate matching coordinate file
+        base = os.path.basename(fname)
+        possible_txt = os.path.join(TXT_DIR, f"{os.path.splitext(base)[0]}.txt")
+        if os.path.exists(possible_txt):
+            self.txt_path = possible_txt
+            self.set_status('图像和坐标已加载', 'green')
+        else:
+            self.txt_path = None
+            self.set_status('图像已加载', 'green')
+        img = Image.open(fname)
+        self.orig_img = ImageTk.PhotoImage(img)
+        self.canvas_orig.config(image=self.orig_img)
+
+    def load_coord(self):
+        fname = filedialog.askopenfilename(initialdir=TXT_DIR, filetypes=[('TXT','*.txt')])
+        if not fname:
+            return
+        self.txt_path = fname
+        self.set_status('坐标已加载', 'green')
+
+    def run_predict(self):
+        if not self.img_path:
+            messagebox.showwarning('提示', '请先加载图像')
+            return
+        basename = os.path.basename(self.img_path)
+        out_path = os.path.join(OUT_DIR, basename)
+        self.set_status('分割中...', 'orange')
+        self.progress.start()
+        self.update_idletasks()
+        predict.process_image(self.img_path, out_path)
+        self.progress.stop()
+        img = Image.open(out_path)
+        self.pred_img = ImageTk.PhotoImage(img)
+        self.canvas_res.config(image=self.pred_img)
+        self.set_status('分割完成', 'green')
+
+    def run_detect(self):
+        if not self.img_path:
+            messagebox.showwarning('提示', '请先加载图像')
+            return
+        if not self.txt_path:
+            base = os.path.basename(self.img_path)
+            auto_txt = os.path.join(TXT_DIR, f"{os.path.splitext(base)[0]}.txt")
+            if os.path.exists(auto_txt):
+                self.txt_path = auto_txt
+            else:
+                messagebox.showwarning('提示', '未找到对应坐标文件')
+                return
+        basename = os.path.basename(self.img_path)
+        out_path = os.path.join(OUT_DIR, basename)
+        if not os.path.exists(out_path):
+            predict.process_image(self.img_path, out_path)
+        self.set_status('检测中...', 'orange')
+        self.progress.start()
+        self.update_idletasks()
+        coords_x, coords_y = detectX3.process_image(out_path, self.txt_path)
+        self.progress.stop()
+        img = Image.open(out_path)
+        draw = ImageDraw.Draw(img)
+        data = detectX3.loadtxtmethod(self.txt_path)
+        b, c, d, a, e, f = data[0], data[1], data[2], data[3], data[4], data[5]
+        w, h = img.size
+        draw.text((5,5), f"{d:.4f},{c:.4f}", fill='white')
+        draw.text((w-150,5), f"{d:.4f},{a:.4f}", fill='white')
+        draw.text((5,h-20), f"{b:.4f},{c:.4f}", fill='white')
+        draw.text((w-150,h-20), f"{b:.4f},{a:.4f}", fill='white')
+        self.det_img = ImageTk.PhotoImage(img)
+        self.canvas_res.config(image=self.det_img)
+        self.set_status('检测完成', 'green')
+
+if __name__ == '__main__':
+    app = App()
+    app.mainloop()

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,26 @@
+import os
+import cv2
+import numpy as np
+
+INPUT_DIR = os.path.join('样例', 'img')
+OUTPUT_DIR = os.path.join('样例', 'img_out')
+
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+def process_image(in_path, out_path):
+    img = cv2.imread(in_path)
+    if img is None:
+        return
+    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    edges = cv2.Canny(gray, 100, 200)
+    output = np.zeros_like(img)
+    output[edges > 0] = (0, 255, 0)
+    cv2.imwrite(out_path, output)
+
+if __name__ == '__main__':
+    for fname in os.listdir(INPUT_DIR):
+        if not fname.lower().endswith(('.jpg', '.png', '.jpeg', '.bmp', '.tif')):
+            continue
+        in_path = os.path.join(INPUT_DIR, fname)
+        out_path = os.path.join(OUTPUT_DIR, fname)
+        process_image(in_path, out_path)


### PR DESCRIPTION
## Summary
- default to `样例/txt_out` for coordinate files
- auto-select matching coordinate text when an image is loaded
- allow `run_detect` to locate the coordinate text automatically
- run segmentation when detection output missing and clean unused imports
- use sample folders for all input/output

## Testing
- `python3 predict.py` *(fails: No module named 'cv2')*
- `python3 gui.py` *(fails: No module named 'PIL')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6867cb4b1228832db756460c3b1cab93